### PR TITLE
Add logger setup for build setup execute

### DIFF
--- a/Assets/UGF.Build.Editor.Tests/TestBuildStepAsset.cs
+++ b/Assets/UGF.Build.Editor.Tests/TestBuildStepAsset.cs
@@ -22,6 +22,8 @@ namespace UGF.Build.Editor.Tests
         protected override void OnExecute(IBuildSetup setup, IContext context)
         {
             Debug.Log($"Execute Build Step: '{Name}'.");
+            Debug.LogWarning($"Execute Build Step: '{Name}'.");
+            Debug.LogError($"Execute Build Step: '{Name}'.");
         }
     }
 

--- a/Packages/UGF.Build/Editor/BuildEditorSettingsData.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorSettingsData.cs
@@ -7,7 +7,7 @@ namespace UGF.Build.Editor
     public class BuildEditorSettingsData : CustomSettingsData
     {
         [SerializeField] private bool m_logEnable = true;
-        [SerializeField] private LogType m_logFilter = LogType.Exception;
+        [SerializeField] private LogType m_logFilter = LogType.Log;
         [SerializeField] private string m_setupNameEnvironmentVariableName = "BuildSetup";
         [SerializeField] private PlatformSettings<BuildPlatformSettings> m_platforms = new PlatformSettings<BuildPlatformSettings>();
 

--- a/Packages/UGF.Build/Editor/BuildEditorUtility.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorUtility.cs
@@ -24,9 +24,14 @@ namespace UGF.Build.Editor
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            IBuildSetup setup = GetSetup(buildTargetGroup, name);
+            BuildEditorSettingsData settings = BuildEditorSettings.Settings.GetData();
 
-            setup.Execute(context);
+            using (new BuildLogScope(settings.LogEnable, settings.LogFilter))
+            {
+                IBuildSetup setup = GetSetup(buildTargetGroup, name);
+
+                setup.Execute(context);
+            }
         }
 
         public static IBuildSetup GetSetup(BuildTargetGroup buildTargetGroup, string name)

--- a/Packages/UGF.Build/Editor/BuildLogScope.cs
+++ b/Packages/UGF.Build/Editor/BuildLogScope.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.Build.Editor
+{
+    public readonly struct BuildLogScope : IDisposable
+    {
+        private readonly bool m_enable;
+        private readonly LogType m_filter;
+
+        public BuildLogScope(bool enable, LogType filter)
+        {
+            m_enable = Debug.unityLogger.logEnabled;
+            m_filter = Debug.unityLogger.filterLogType;
+
+            Debug.unityLogger.logEnabled = enable;
+            Debug.unityLogger.filterLogType = filter;
+        }
+
+        public void Dispose()
+        {
+            Debug.unityLogger.logEnabled = m_enable;
+            Debug.unityLogger.filterLogType = m_filter;
+        }
+    }
+}

--- a/Packages/UGF.Build/Editor/BuildLogScope.cs.meta
+++ b/Packages/UGF.Build/Editor/BuildLogScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fc3196964d66427083ff69193f954b52
+timeCreated: 1629654731

--- a/ProjectSettings/Packages/UGF.Build/BuildEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Build/BuildEditorSettings.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_logEnable: 1
-  m_logFilter: 4
+  m_logFilter: 3
   m_setupNameEnvironmentVariableName: BuildSetup
   m_platforms:
     m_groups:


### PR DESCRIPTION
- Add `BuildLogScope` disposable structure to create scope with specific logger options.
- Change `BuildEditorUtility.Execute()` methods to use log settings from `BuildEditorSettings` settings.