### PR TITLE
Fix missing SetupNameEnvironmentVariableName in editor settings

### DIFF
--- a/Packages/UGF.Build/Editor/BuildEditorSettingsData.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorSettingsData.cs
@@ -8,7 +8,7 @@ namespace UGF.Build.Editor
     {
         [SerializeField] private bool m_logEnable = true;
         [SerializeField] private LogType m_logFilter = LogType.Log;
-        [SerializeField] private string m_setupNameEnvironmentVariableName = "BuildSetup";
+        [SerializeField] private string m_setupNameEnvironmentVariableName = "BUILD_SETUP";
         [SerializeField] private PlatformSettings<BuildPlatformSettings> m_platforms = new PlatformSettings<BuildPlatformSettings>();
 
         public bool LogEnable { get { return m_logEnable; } set { m_logEnable = value; } }

--- a/Packages/UGF.Build/Editor/BuildEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorSettingsDataEditor.cs
@@ -9,6 +9,7 @@ namespace UGF.Build.Editor
         private readonly BuildEditorSettingsDataPlatformsDrawer m_platformsDrawer = new BuildEditorSettingsDataPlatformsDrawer();
         private SerializedProperty m_propertyLogEnable;
         private SerializedProperty m_propertyLogFilter;
+        private SerializedProperty m_propertySetupNameEnvironmentVariableName;
         private SerializedProperty m_propertyPlatformsGroups;
 
         private void OnEnable()
@@ -17,6 +18,7 @@ namespace UGF.Build.Editor
 
             m_propertyLogEnable = serializedObject.FindProperty("m_logEnable");
             m_propertyLogFilter = serializedObject.FindProperty("m_logFilter");
+            m_propertySetupNameEnvironmentVariableName = serializedObject.FindProperty("m_setupNameEnvironmentVariableName");
             m_propertyPlatformsGroups = serializedObject.FindProperty("m_platforms.m_groups");
         }
 
@@ -31,6 +33,7 @@ namespace UGF.Build.Editor
             {
                 EditorGUILayout.PropertyField(m_propertyLogEnable);
                 EditorGUILayout.PropertyField(m_propertyLogFilter);
+                EditorGUILayout.PropertyField(m_propertySetupNameEnvironmentVariableName);
                 EditorGUILayout.Space();
 
                 m_platformsDrawer.DrawGUILayout(m_propertyPlatformsGroups);

--- a/Packages/UGF.Build/Editor/BuildEditorSettingsDataPlatformsDrawer.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorSettingsDataPlatformsDrawer.cs
@@ -59,17 +59,15 @@ namespace UGF.Build.Editor
             float height = EditorGUIUtility.singleLineHeight;
             float space = EditorGUIUtility.standardVerticalSpacing;
 
-            PlatformInfo platform = GetPlatformInfo(name);
             SerializedProperty propertySettings = OnGetSettings(propertyGroups, name);
+            ReorderableListDrawer drawer = GetListDrawer(name, propertySettings);
 
             using (new LabelWidthChangeScope(-PADDING))
             {
                 var rectPlatformName = new Rect(position.x, position.y, position.width, height);
                 var rectSetups = new Rect(position.x, rectPlatformName.yMax + space, position.width, height);
 
-                EditorGUI.LabelField(rectPlatformName, $"Settings for {platform.Label.text}");
-
-                ReorderableListDrawer drawer = GetListDrawer(name, propertySettings);
+                OnDrawSettingsPlatformName(rectPlatformName, propertyGroups, name);
 
                 drawer.DrawGUI(rectSetups);
             }

--- a/Packages/UGF.Build/package.json
+++ b/Packages/UGF.Build/package.json
@@ -19,7 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.editortools": "1.12.0",
+    "com.ugf.editortools": "1.13.0",
     "com.ugf.customsettings": "3.4.1",
     "com.ugf.runtimetools": "2.3.0",
     "com.ugf.builder": "2.0.1"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -5,7 +5,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.editortools": "1.12.0",
+        "com.ugf.editortools": "1.13.0",
         "com.ugf.customsettings": "3.4.1",
         "com.ugf.runtimetools": "2.3.0",
         "com.ugf.builder": "2.0.1"
@@ -29,7 +29,7 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.12.0",
+      "version": "1.13.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/Packages/UGF.Build/BuildEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Build/BuildEditorSettings.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_logEnable: 1
   m_logFilter: 3
-  m_setupNameEnvironmentVariableName: BuildSetup
+  m_setupNameEnvironmentVariableName: BUILD_SETUP
   m_platforms:
     m_groups:
     - m_name: Standalone


### PR DESCRIPTION
- Update dependencies: `com.ugf.editortools` to `1.13.0` version.
- Fix missing `SetupNameEnvironmentVariableName` property in _BuildEditorSettings_ project settings.