### PR TITLE
Add build step auto name

### DIFF
--- a/Packages/UGF.Build/Editor/BuildSetup.cs
+++ b/Packages/UGF.Build/Editor/BuildSetup.cs
@@ -52,5 +52,10 @@ namespace UGF.Build.Editor
 
             Debug.Log($"Build Setup End: '{Name}', time: '{setupWatch.Elapsed.TotalMilliseconds}ms'.");
         }
+
+        public override string ToString()
+        {
+            return $"{Name} ({GetType().FullName})";
+        }
     }
 }

--- a/Packages/UGF.Build/Editor/BuildStep.cs
+++ b/Packages/UGF.Build/Editor/BuildStep.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UGF.RuntimeTools.Runtime.Contexts;
+using UnityEditor;
 
 namespace UGF.Build.Editor
 {
@@ -7,8 +8,9 @@ namespace UGF.Build.Editor
     {
         public string Name { get; }
 
-        protected BuildStep() : this("Untitled Step")
+        protected BuildStep()
         {
+            Name = ObjectNames.NicifyVariableName(GetType().Name);
         }
 
         protected BuildStep(string name)
@@ -30,7 +32,7 @@ namespace UGF.Build.Editor
 
         public override string ToString()
         {
-            return Name;
+            return $"{Name} ({GetType().FullName})";
         }
     }
 }


### PR DESCRIPTION
- Add `BuildStep` auto naming using name of the type when creating class without specified name. 