### PR TITLE
Add pre and post export setup name env variable settings

### DIFF
--- a/Packages/UGF.Build/Editor/BatchMode/BatchModeBuild.cs
+++ b/Packages/UGF.Build/Editor/BatchMode/BatchModeBuild.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Build.Editor.BatchMode
 {
@@ -7,13 +8,13 @@ namespace UGF.Build.Editor.BatchMode
         [UsedImplicitly]
         public static void PreExport()
         {
-            BuildEditorUtility.Execute();
+            BuildEditorUtility.ExecutePreExport(new Context());
         }
 
         [UsedImplicitly]
         public static void PostExport()
         {
-            BuildEditorUtility.Execute();
+            BuildEditorUtility.ExecutePostExport(new Context());
         }
     }
 }

--- a/Packages/UGF.Build/Editor/BuildEditorSettingsData.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorSettingsData.cs
@@ -8,12 +8,14 @@ namespace UGF.Build.Editor
     {
         [SerializeField] private bool m_logEnable = true;
         [SerializeField] private LogType m_logFilter = LogType.Log;
-        [SerializeField] private string m_setupNameEnvironmentVariableName = "BUILD_SETUP";
+        [SerializeField] private string m_preExportSetupNameEnvironmentVariable = "BUILD_PRE_EXPORT_SETUP";
+        [SerializeField] private string m_postExportSetupNameEnvironmentVariable = "BUILD_POST_EXPORT_SETUP";
         [SerializeField] private PlatformSettings<BuildPlatformSettings> m_platforms = new PlatformSettings<BuildPlatformSettings>();
 
         public bool LogEnable { get { return m_logEnable; } set { m_logEnable = value; } }
         public LogType LogFilter { get { return m_logFilter; } set { m_logFilter = value; } }
-        public string SetupNameEnvironmentVariableName { get { return m_setupNameEnvironmentVariableName; } set { m_setupNameEnvironmentVariableName = value; } }
+        public string PreExportSetupNameEnvironmentVariable { get { return m_preExportSetupNameEnvironmentVariable; } set { m_preExportSetupNameEnvironmentVariable = value; } }
+        public string PostExportSetupNameEnvironmentVariable { get { return m_postExportSetupNameEnvironmentVariable; } set { m_postExportSetupNameEnvironmentVariable = value; } }
         public PlatformSettings<BuildPlatformSettings> Platforms { get { return m_platforms; } }
     }
 }

--- a/Packages/UGF.Build/Editor/BuildEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorSettingsDataEditor.cs
@@ -9,7 +9,8 @@ namespace UGF.Build.Editor
         private readonly BuildEditorSettingsDataPlatformsDrawer m_platformsDrawer = new BuildEditorSettingsDataPlatformsDrawer();
         private SerializedProperty m_propertyLogEnable;
         private SerializedProperty m_propertyLogFilter;
-        private SerializedProperty m_propertySetupNameEnvironmentVariableName;
+        private SerializedProperty m_propertyPreExportSetupNameEnvironmentVariable;
+        private SerializedProperty m_propertyPostExportSetupNameEnvironmentVariable;
         private SerializedProperty m_propertyPlatformsGroups;
 
         private void OnEnable()
@@ -18,7 +19,8 @@ namespace UGF.Build.Editor
 
             m_propertyLogEnable = serializedObject.FindProperty("m_logEnable");
             m_propertyLogFilter = serializedObject.FindProperty("m_logFilter");
-            m_propertySetupNameEnvironmentVariableName = serializedObject.FindProperty("m_setupNameEnvironmentVariableName");
+            m_propertyPreExportSetupNameEnvironmentVariable = serializedObject.FindProperty("m_preExportSetupNameEnvironmentVariable");
+            m_propertyPostExportSetupNameEnvironmentVariable = serializedObject.FindProperty("m_postExportSetupNameEnvironmentVariable");
             m_propertyPlatformsGroups = serializedObject.FindProperty("m_platforms.m_groups");
         }
 
@@ -33,7 +35,8 @@ namespace UGF.Build.Editor
             {
                 EditorGUILayout.PropertyField(m_propertyLogEnable);
                 EditorGUILayout.PropertyField(m_propertyLogFilter);
-                EditorGUILayout.PropertyField(m_propertySetupNameEnvironmentVariableName);
+                EditorGUILayout.PropertyField(m_propertyPreExportSetupNameEnvironmentVariable);
+                EditorGUILayout.PropertyField(m_propertyPostExportSetupNameEnvironmentVariable);
                 EditorGUILayout.Space();
 
                 m_platformsDrawer.DrawGUILayout(m_propertyPlatformsGroups);

--- a/Packages/UGF.Build/Editor/BuildEditorUtility.cs
+++ b/Packages/UGF.Build/Editor/BuildEditorUtility.cs
@@ -8,15 +8,24 @@ namespace UGF.Build.Editor
 {
     public static class BuildEditorUtility
     {
-        public static void Execute()
+        public static void ExecutePreExport(IContext context)
         {
-            Execute(new Context());
+            BuildEditorSettingsData settings = BuildEditorSettings.Settings.GetData();
+            string name = GetSetupNameFromEnvironmentVariables(settings.PreExportSetupNameEnvironmentVariable);
+
+            Execute(name, context);
         }
 
-        public static void Execute(IContext context)
+        public static void ExecutePostExport(IContext context)
         {
-            string name = GetSetupNameFromEnvironmentVariables();
+            BuildEditorSettingsData settings = BuildEditorSettings.Settings.GetData();
+            string name = GetSetupNameFromEnvironmentVariables(settings.PostExportSetupNameEnvironmentVariable);
 
+            Execute(name, context);
+        }
+
+        public static void Execute(string name, IContext context)
+        {
             Execute(EditorUserBuildSettings.selectedBuildTargetGroup, name, context);
         }
 
@@ -57,16 +66,16 @@ namespace UGF.Build.Editor
             return data.Platforms.TryGetSettings(buildTargetGroup, out BuildPlatformSettings settings) && TryGetSetup(settings, name, out setup);
         }
 
-        public static string GetSetupNameFromEnvironmentVariables()
+        public static string GetSetupNameFromEnvironmentVariables(string environmentVariableName)
         {
-            return TryGetSetupNameFromEnvironmentVariables(out string name) ? name : throw new ArgumentException("Environment variable not found.");
+            return TryGetSetupNameFromEnvironmentVariables(environmentVariableName, out string name) ? name : throw new ArgumentException("Environment variable not found.");
         }
 
-        public static bool TryGetSetupNameFromEnvironmentVariables(out string name)
+        public static bool TryGetSetupNameFromEnvironmentVariables(string environmentVariableName, out string name)
         {
-            BuildEditorSettingsData data = BuildEditorSettings.Settings.GetData();
+            if (string.IsNullOrEmpty(environmentVariableName)) throw new ArgumentException("Value cannot be null or empty.", nameof(environmentVariableName));
 
-            name = Environment.GetEnvironmentVariable(data.SetupNameEnvironmentVariableName);
+            name = Environment.GetEnvironmentVariable(environmentVariableName);
             return !string.IsNullOrEmpty(name);
         }
 

--- a/Packages/UGF.Build/Editor/UnityCloud/UnityCloudBuild.cs
+++ b/Packages/UGF.Build/Editor/UnityCloud/UnityCloudBuild.cs
@@ -1,4 +1,6 @@
 ﻿using JetBrains.Annotations;
+using UGF.Build.Runtime.UnityCloud;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Build.Editor.UnityCloud
 {
@@ -7,13 +9,17 @@ namespace UGF.Build.Editor.UnityCloud
         [UsedImplicitly]
         public static void PreExport()
         {
-            BuildEditorUtility.Execute();
+            UnityCloudBuildManifest manifest = UnityCloudBuildEditorUtility.GetManifest();
+
+            BuildEditorUtility.ExecutePreExport(new Context { manifest });
         }
 
         [UsedImplicitly]
         public static void PostExport()
         {
-            BuildEditorUtility.Execute();
+            UnityCloudBuildManifest manifest = UnityCloudBuildEditorUtility.GetManifest();
+
+            BuildEditorUtility.ExecutePostExport(new Context { manifest });
         }
     }
 }

--- a/Packages/UGF.Build/Editor/UnityCloud/UnityCloudBuildEditorUtility.cs
+++ b/Packages/UGF.Build/Editor/UnityCloud/UnityCloudBuildEditorUtility.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UGF.Build.Runtime.UnityCloud;
-using UGF.RuntimeTools.Runtime.Contexts;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -9,14 +8,6 @@ namespace UGF.Build.Editor.UnityCloud
     public static class UnityCloudBuildEditorUtility
     {
         private const string MANIFEST_RESOURCES_NAME = "UnityCloudBuildManifest.scriptable";
-
-        public static void Execute()
-        {
-            UnityCloudBuildManifest manifest = GetManifest();
-            var context = new Context { manifest };
-
-            BuildEditorUtility.Execute(context);
-        }
 
         public static bool HasManifest()
         {

--- a/ProjectSettings/Packages/UGF.Build/BuildEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Build/BuildEditorSettings.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_logEnable: 1
   m_logFilter: 3
-  m_setupNameEnvironmentVariableName: BUILD_SETUP
+  m_preExportSetupNameEnvironmentVariable: BUILD_PRE_EXPORT_SETUP
+  m_postExportSetupNameEnvironmentVariable: BUILD_POST_EXPORT_SETUP
   m_platforms:
     m_groups:
     - m_name: Standalone


### PR DESCRIPTION
- Add `BuildEditorSettingsData.PreExportSetupNameEnvironmentVariable` property to define environment variable with setup name for pre export execution.
- Add `BuildEditorSettingsData.PostExportSetupNameEnvironmentVariable` property to define environment variable with setup name for post export execution.
- Add `BuildEditorUtility.ExecutePreExport()` and `PostExport()` methods used to execute setup from environment variables and specified context.
- Change `BuildEditorUtility.TryGetSetupNameFromEnvironmentVariables()` and `GetSetupNameFromEnvironmentVariables()` methods to require environment variable name to get setup name from.
- Fix `UnityCloudBuild.PreExport()` and `PostExport()` methods create context with _Unity Cloud Build_ manifest included.
- Remove `BuildEditorSettingsData.SetupNameEnvironmentVariableName` property, use `PreExportSetupNameEnvironmentVariable` and `PostExportSetupNameEnvironmentVariable` properties instead.
- Remove `BuildEditorUtility.Execute()` method with zero arguments.
- Remove `UnityCloudBuildEditorUtility.Execute()` method.