### PR TITLE
Add build report for context of post export execution

### DIFF
--- a/Packages/UGF.Build/Editor/BatchMode/BatchModeBuild.cs
+++ b/Packages/UGF.Build/Editor/BatchMode/BatchModeBuild.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using UGF.RuntimeTools.Runtime.Contexts;
+using UnityEditor.Build.Reporting;
 
 namespace UGF.Build.Editor.BatchMode
 {
@@ -14,6 +15,13 @@ namespace UGF.Build.Editor.BatchMode
         [UsedImplicitly]
         public static void PostExport()
         {
+            var context = new Context();
+
+            if (BuildEditorUtility.TryGetBuildReport(out BuildReport report))
+            {
+                context.Add(report);
+            }
+
             BuildEditorUtility.ExecutePostExport(new Context());
         }
     }

--- a/Packages/UGF.Build/Editor/UnityCloud/UnityCloudBuild.cs
+++ b/Packages/UGF.Build/Editor/UnityCloud/UnityCloudBuild.cs
@@ -1,6 +1,7 @@
 ﻿using JetBrains.Annotations;
 using UGF.Build.Runtime.UnityCloud;
 using UGF.RuntimeTools.Runtime.Contexts;
+using UnityEditor.Build.Reporting;
 
 namespace UGF.Build.Editor.UnityCloud
 {
@@ -18,8 +19,14 @@ namespace UGF.Build.Editor.UnityCloud
         public static void PostExport()
         {
             UnityCloudBuildManifest manifest = UnityCloudBuildEditorUtility.GetManifest();
+            var context = new Context { manifest };
 
-            BuildEditorUtility.ExecutePostExport(new Context { manifest });
+            if (BuildEditorUtility.TryGetBuildReport(out BuildReport report))
+            {
+                context.Add(report);
+            }
+
+            BuildEditorUtility.ExecutePostExport(context);
         }
     }
 }


### PR DESCRIPTION
- Add `BuildReport` object into context for `BatchModeBuild` and `UnityCloudBuild` _PostExport_ methods.